### PR TITLE
Add ability to refresh projects & dbcontexts

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,23 @@
       },
       {
         "command": "entityframework.refreshTree",
-        "title": "Refresh Migrations",
+        "title": "Refresh",
+        "icon": {
+          "light": "icons/refresh_light.svg",
+          "dark": "icons/refresh_dark.svg"
+        }
+      },
+      {
+        "command": "entityframework.refreshDbContextTree",
+        "title": "Refresh",
+        "icon": {
+          "light": "icons/refresh_light.svg",
+          "dark": "icons/refresh_dark.svg"
+        }
+      },
+      {
+        "command": "entityframework.refreshProjectTree",
+        "title": "Refresh",
         "icon": {
           "light": "icons/refresh_light.svg",
           "dark": "icons/refresh_dark.svg"
@@ -127,6 +143,14 @@
       "commandPalette": [
         {
           "command": "entityframework.refreshTree",
+          "when": "false"
+        },
+        {
+          "command": "entityframework.refreshProjectTree",
+          "when": "false"
+        },
+        {
+          "command": "entityframework.refreshDbContextTree",
           "when": "false"
         },
         {
@@ -212,33 +236,19 @@
         },
         {
           "command": "entityframework.generateScript",
-          "when": "viewItem == dbContext",
-          "group": "inline@3"
-        },
-        {
-          "command": "entityframework.generateScript",
-          "when": "viewItem == dbContext",
-          "group": "context@2"
+          "when": "viewItem == dbContext"
         },
         {
           "command": "entityframework.generateERD",
-          "when": "viewItem == dbContext",
-          "group": "inline@2"
-        },
-        {
-          "command": "entityframework.generateERD",
-          "when": "viewItem == dbContext",
-          "group": "context@3"
+          "when": "viewItem == dbContext"
         },
         {
           "command": "entityframework.dbContextInfo",
-          "when": "viewItem == dbContext",
-          "group": "inline@1"
+          "when": "viewItem == dbContext"
         },
         {
-          "command": "entityframework.dbContextInfo",
-          "when": "viewItem == dbContext",
-          "group": "context@4"
+          "command": "entityframework.refreshDbContextTree",
+          "when": "viewItem == dbContext"
         },
         {
           "command": "entityframework.scaffold",
@@ -249,6 +259,11 @@
           "command": "entityframework.scaffold",
           "when": "viewItem == project",
           "group": "context@1"
+        },
+        {
+          "command": "entityframework.refreshProjectTree",
+          "when": "viewItem == project",
+          "group": "context@2"
         }
       ]
     },

--- a/src/actions/RefreshDbContextTreeAction.ts
+++ b/src/actions/RefreshDbContextTreeAction.ts
@@ -1,0 +1,26 @@
+import * as vscode from 'vscode';
+import { CommandProvider } from '../commands/CommandProvider';
+import { RefreshTreeCommand } from '../commands/RefreshTreeCommand';
+
+import {
+  dbContextsCache,
+  DbContextTreeItem,
+} from '../treeView/DbContextTreeItem';
+import type { IAction } from './IAction';
+
+export class RefreshDbContextTreeAction implements IAction {
+  constructor(private readonly item: DbContextTreeItem) {}
+
+  public async run() {
+    const cacheId = DbContextTreeItem.getCacheId(
+      this.item.workspaceRoot,
+      this.item.projectFile.name,
+      this.item.label,
+    );
+    dbContextsCache.clear(cacheId);
+    await vscode.commands.executeCommand(
+      CommandProvider.getCommandName(RefreshTreeCommand.commandName),
+      false,
+    );
+  }
+}

--- a/src/actions/RefreshProjectTreeAction.ts
+++ b/src/actions/RefreshProjectTreeAction.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+import { CommandProvider } from '../commands/CommandProvider';
+import { RefreshTreeCommand } from '../commands/RefreshTreeCommand';
+import { projectsCache, ProjectTreeItem } from '../treeView/ProjectTreeItem';
+import type { IAction } from './IAction';
+
+export class RefreshProjectTreeAction implements IAction {
+  constructor(private readonly item: ProjectTreeItem) {}
+
+  public async run() {
+    const cacheId = ProjectTreeItem.getCacheId(
+      this.item.workspaceRoot,
+      this.item.label,
+    );
+    projectsCache.clear(cacheId);
+    await vscode.commands.executeCommand(
+      CommandProvider.getCommandName(RefreshTreeCommand.commandName),
+      false,
+    );
+  }
+}

--- a/src/actions/RefreshTreeAction.ts
+++ b/src/actions/RefreshTreeAction.ts
@@ -1,0 +1,17 @@
+import { clearTreeCache } from '../treeView/treeCache';
+import type { TreeDataProvider } from '../treeView/TreeDataProvider';
+import type { IAction } from './IAction';
+
+export class RefreshTreeAction implements IAction {
+  constructor(
+    private readonly treeDataProvider: TreeDataProvider,
+    private readonly clearCache = true,
+  ) {}
+
+  public async run() {
+    if (this.clearCache) {
+      clearTreeCache();
+    }
+    this.treeDataProvider.refresh();
+  }
+}

--- a/src/cli/EFOutputParser.ts
+++ b/src/cli/EFOutputParser.ts
@@ -48,9 +48,9 @@ export class EFOutputParser {
   }
 
   public static parse(output: string) {
-    let warnings = '';
-    let data = '';
-    let errors = '';
+    let warnings: string[] = [];
+    let data: string[] = [];
+    let errors: string[] = [];
     let matchedWarning = false;
     let matchedError = false;
 
@@ -72,18 +72,18 @@ export class EFOutputParser {
       const lineWithoutPrefix = line.replace(OUTPUT_PREFIX, '');
 
       if (matchedWarning) {
-        warnings += lineWithoutPrefix;
+        warnings.push(lineWithoutPrefix);
       } else if (matchedError) {
-        errors += lineWithoutPrefix;
+        errors.push(lineWithoutPrefix);
       } else if (matchedData) {
-        data += lineWithoutPrefix;
+        data.push(lineWithoutPrefix);
       }
     });
 
     return {
-      warnings,
-      errors,
-      data,
+      warnings: warnings.join('\n'),
+      errors: errors.join('\n'),
+      data: data.join('\n'),
     };
   }
 }

--- a/src/commands/CommandProvider.ts
+++ b/src/commands/CommandProvider.ts
@@ -4,6 +4,7 @@ import { EXTENSION_NAMESPACE } from '../constants/constants';
 import type { TerminalProvider } from '../terminal/TerminalProvider';
 import type { DbContextTreeItem } from '../treeView/DbContextTreeItem';
 import type { MigrationTreeItem } from '../treeView/MigrationTreeItem';
+import type { ProjectTreeItem } from '../treeView/ProjectTreeItem';
 import type { TreeDataProvider } from '../treeView/TreeDataProvider';
 import { Disposable } from '../util/Disposable';
 import type { Logger } from '../util/Logger';
@@ -13,6 +14,8 @@ import { DBContextInfoCommand } from './DBContextInfoCommand';
 import { GenerateERDCommand } from './GenerateERDCommand';
 import { GenerateScriptCommand } from './GenerateScriptCommand';
 import { OpenMigrationFileCommand } from './OpenMigrationFileCommand';
+import { RefreshDbContextTreeCommand } from './RefreshDbContextTreeCommand';
+import { RefreshProjectTreeCommand } from './RefreshProjectTreeCommand';
 import { RefreshTreeCommand } from './RefreshTreeCommand';
 import { RemoveMigrationsCommand } from './RemoveMigrationsCommand';
 import { RunMigrationCommand } from './RunMigrationCommand';
@@ -69,6 +72,14 @@ export class CommandProvider extends Disposable {
       RefreshTreeCommand.commandName,
       (clearCache: boolean) =>
         new RefreshTreeCommand(treeDataProvider, clearCache),
+    );
+    this.registerCommand(
+      RefreshDbContextTreeCommand.commandName,
+      (item?: DbContextTreeItem) => new RefreshDbContextTreeCommand(item),
+    );
+    this.registerCommand(
+      RefreshProjectTreeCommand.commandName,
+      (item?: ProjectTreeItem) => new RefreshProjectTreeCommand(item),
     );
     this.registerCommand(
       OpenMigrationFileCommand.commandName,

--- a/src/commands/RefreshDbContextTreeCommand.ts
+++ b/src/commands/RefreshDbContextTreeCommand.ts
@@ -1,0 +1,18 @@
+import { RefreshDbContextTreeAction } from '../actions/RefreshDbContextTreeAction';
+import type { DbContextTreeItem } from '../treeView/DbContextTreeItem';
+import { Command } from './Command';
+
+export class RefreshDbContextTreeCommand extends Command {
+  public static commandName = 'refreshDbContextTree';
+
+  constructor(private readonly item?: DbContextTreeItem) {
+    super();
+  }
+
+  public async run() {
+    if (!this.item) {
+      return;
+    }
+    await new RefreshDbContextTreeAction(this.item).run();
+  }
+}

--- a/src/commands/RefreshProjectTreeCommand.ts
+++ b/src/commands/RefreshProjectTreeCommand.ts
@@ -1,0 +1,18 @@
+import { RefreshProjectTreeAction } from '../actions/RefreshProjectTreeAction';
+import type { ProjectTreeItem } from '../treeView/ProjectTreeItem';
+import { Command } from './Command';
+
+export class RefreshProjectTreeCommand extends Command {
+  public static commandName = 'refreshProjectTree';
+
+  constructor(private readonly item?: ProjectTreeItem) {
+    super();
+  }
+
+  public async run() {
+    if (!this.item) {
+      return;
+    }
+    await new RefreshProjectTreeAction(this.item).run();
+  }
+}

--- a/src/commands/RefreshTreeCommand.ts
+++ b/src/commands/RefreshTreeCommand.ts
@@ -1,4 +1,4 @@
-import { clearTreeCache } from '../treeView/treeCache';
+import { RefreshTreeAction } from '../actions/RefreshTreeAction';
 import type { TreeDataProvider } from '../treeView/TreeDataProvider';
 import { Command } from './Command';
 
@@ -13,9 +13,6 @@ export class RefreshTreeCommand extends Command {
   }
 
   public async run() {
-    if (this.clearCache) {
-      clearTreeCache();
-    }
-    this.treeDataProvider.refresh();
+    await new RefreshTreeAction(this.treeDataProvider, this.clearCache).run();
   }
 }

--- a/src/commands/RemoveMigrationsCommand.ts
+++ b/src/commands/RemoveMigrationsCommand.ts
@@ -28,7 +28,7 @@ export class RemoveMigrationsCommand extends Command {
         this.item.dbContext,
       ),
     );
-    const index = migrations?.indexOf(this.item) || -1;
+    const index = (migrations || []).indexOf(this.item);
     if (index === -1) {
       return;
     }


### PR DESCRIPTION
Fixes #37

I've also tidied up the tree item actions. Unfortunately you can't create secondary actions with a ... sub-menu (you can only do that for top level tree navigation items), so secondary actions are displayed in the context menu:

<img width="393" alt="Screenshot 2023-01-03 at 18 38 37" src="https://user-images.githubusercontent.com/102141/210420482-ae3b0480-e5e4-4502-b9af-ab866137765d.png">
