### PR TITLE
Fix issue where extention would crash when NugetDepsTree.generate return no projects

### DIFF
--- a/src/solution/ProjectFilesProvider.ts
+++ b/src/solution/ProjectFilesProvider.ts
@@ -33,13 +33,12 @@ export class ProjectFilesProvider {
           workspaceRoot.uri.fsPath,
           path.dirname(projectFile.fsPath),
         );
-        const { projects } = NugetDepsTree.generate(projectFile.fsPath);
 
         const { projects } = NugetDepsTree.generate(projectFile.fsPath);
         if (projects.length === 0) {
           continue;
         }
-        
+
         const [project] = projects;
         const hasEFDesignPackage =
           ProjectFilesProvider.getProjectPackage(

--- a/src/solution/ProjectFilesProvider.ts
+++ b/src/solution/ProjectFilesProvider.ts
@@ -34,6 +34,12 @@ export class ProjectFilesProvider {
           path.dirname(projectFile.fsPath),
         );
         const { projects } = NugetDepsTree.generate(projectFile.fsPath);
+
+        const { projects } = NugetDepsTree.generate(projectFile.fsPath);
+        if (projects.length === 0) {
+          continue;
+        }
+        
         const [project] = projects;
         const hasEFDesignPackage =
           ProjectFilesProvider.getProjectPackage(


### PR DESCRIPTION
Prevent undefined project destructuring by adding a check for an empty projects array in ProjectFilesProvider. This situation can occur when the .csproj file is present on disk, but the parser (i.e., NugetDepsTree.generate) doesn't find any valid project information within it. For example, if the project file is malformed or uses an unsupported structure.